### PR TITLE
Delay Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,21 @@ It is now possible to modify, add, or delete files without the requirement of re
 ## Endpoints
 The following endpoints are available:
 
-### GET /api/v1/file/{name}
+### GET `/api/v1/file/{name}`
 Retrieves a specific file based on its name and parses its data based on its extension. Currently, it supports parsing of JSON formatted files with the ".json" extension, as well as text files without an extension.
+
+
+<br />
+
+## Features
+The following features are available:
+
+### Delay
+The delay middleware that allows you to add a delay to your HTTP requests. This is useful for testing purposes, or for simulating slow responses in a controlled environment. The middleware reads the value of the "delay" query parameter from the URL of the incoming request. If the "delay" parameter is present, the middleware parses the duration from its value and waits for the specified duration using the `time.Sleep` function. If the duration value is not valid, the middleware returns a "400 Bad Request" HTTP response with an error message.
+```shell
+curl 'http://localhost:8181/api/v1/ping?delay=2s'
+curl 'http://localhost:8181/api/v1/file/users.json?delay=5s' | json_pp
+```
 
 
 <br />

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/alsolovyev/dummy-api/internal/entity"
 	"github.com/go-chi/chi/v5"
@@ -14,10 +16,30 @@ func New(f entity.FileUseCaser) *chi.Mux {
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 
+	r.Use(delayMiddleware)
+
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Get("/ping", handlePing)
 		r.With(filenameMiddleware).Get(fmt.Sprintf("/file/{%s}", filenameKey), handleFile(f))
 	})
 
 	return r
+}
+
+func delayMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+
+		if q["delay"] != nil {
+			d, err := time.ParseDuration(q["delay"][0])
+
+			if err != nil {
+				entity.NewError(http.StatusBadRequest, "Invalid dealy value").Render(w)
+				return
+			}
+			time.Sleep(d)
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -11,7 +11,7 @@ const (
 	idleTimeout    = 5 * time.Second
 	maxHeaderBytes = 1 << 20
 	readTimeout    = 10 * time.Second
-	writeTimeout   = 10 * time.Second
+	writeTimeout   = 60 * time.Second
 )
 
 type Server struct {


### PR DESCRIPTION
The delay middleware that allows you to add a delay to your HTTP requests. This is useful for testing purposes, or for simulating slow responses in a controlled environment. The middleware reads the value of the "delay" query parameter from the URL of the incoming request. If the "delay" parameter is present, the middleware parses the duration from its value and waits for the specified duration using the `time.Sleep` function. If the duration value is not valid, the middleware returns a "400 Bad Request" HTTP response with an error message.

 ```shell
 curl 'http://localhost:8181/api/v1/ping?delay=2s'
 curl 'http://localhost:8181/api/v1/file/users.json?delay=5s' | json_pp
 ```